### PR TITLE
Support multiple feedback types in issue creation workflow

### DIFF
--- a/.github/workflows/create-issue-from-feedback.yml
+++ b/.github/workflows/create-issue-from-feedback.yml
@@ -20,7 +20,9 @@ jobs:
           script: |
             const payload = context.payload.client_payload;
 
-            const type = payload.type || 'word_search';
+            const allowedTypes = ['word_search', 'chunk'];
+            const rawType = payload.type || 'word_search';
+            const type = allowedTypes.includes(rawType) ? rawType : 'word_search';
             const word = payload.word || '';
             const expectation = payload.expectation || '';
             const comment = payload.comment || '';
@@ -77,12 +79,18 @@ jobs:
               '**参照元辞書**: ' + sourceDict,
             ];
 
-            const issueBody = [
-              ...(type === 'chunk' ? chunkBody : wordSearchBody),
+            const footerLines = [
               '---',
               '_スプレッドシート行: ' + rowIndex + '_',
               '_このIssueは自動作成されました。内容を確認し、問題なければ「approved」ラベルを付与してください。_',
-              '_検索ロジックの改善が必要な場合は「search-improvement」ラベルを付与してください。_'
+            ];
+            if (type === 'word_search') {
+              footerLines.push('_検索ロジックの改善が必要な場合は「search-improvement」ラベルを付与してください。_');
+            }
+
+            const issueBody = [
+              ...(type === 'chunk' ? chunkBody : wordSearchBody),
+              ...footerLines,
             ].join('\n');
 
             const titlePrefixes = { 'chunk': '【チャンク提案】', 'word_search': '【検索不具合】' };


### PR DESCRIPTION
## Summary
Enhanced the GitHub Actions workflow for creating issues from feedback to support multiple feedback types beyond word search, including chunk proposals. The workflow now dynamically generates issue titles, bodies, and labels based on the feedback type.

## Key Changes
- Added support for a `type` parameter (defaults to `word_search`) to distinguish between different feedback categories
- Introduced `source_dictionary` parameter to track the reference dictionary source (defaults to '自分で作成')
- Refactored issue body generation to use reusable `commonChecklist` component shared across feedback types
- Created type-specific issue body templates:
  - `wordSearchBody`: For word search feedback with word-specific fields (part of speech, post URL, row index)
  - `chunkBody`: For chunk proposals with phrase-specific fields
- Implemented dynamic title prefix mapping based on feedback type:
  - `【検索不具合】` for word_search
  - `【チャンク提案】` for chunk
  - `【フィードバック】` as fallback
- Changed issue labels from hardcoded `['word_search']` to dynamic `[type]` for better categorization

## Implementation Details
- The common checklist section (copyright warnings and reference dictionary links) is now shared across all feedback types using spread operator
- Each feedback type maintains its own specific fields and structure while leveraging the shared checklist
- The workflow maintains backward compatibility by defaulting to `word_search` type when not specified

https://claude.ai/code/session_01TEehj1W9xDQcRN9LRKEE6G